### PR TITLE
Add CXX for cross compilation

### DIFF
--- a/scripts/build_otp.sh
+++ b/scripts/build_otp.sh
@@ -78,7 +78,8 @@ if [ ! -d otp_src_${version} ]; then
 
     # set cross comp flags and compiler target flags
     export CC="$CC -target arm64-apple-macos11"
-    export OTP_BUILD_FLAGS="$OTP_BUILD_FLAGS --host=arm64-apple-darwin --build=x86_64-apple-darwin"
+    export CXX="$clang++ -target arm64-apple-macos11"
+    export OTP_BUILD_FLAGS="$OTP_BUILD_FLAGS --host=aarch64-apple-darwin --build=x86_64-apple-darwin"
     export arch="darwin-arm64"
     export erl_xcomp_sysroot="$OpenSSL_DIR"
   fi


### PR DESCRIPTION
This fixes the failing Mac silicon build.

As Github Actions doesn't like forks, I tested this on a separate repo. Sample releases are available [here](https://github.com/hochata/burrito_builder/releases).

Closes #2 